### PR TITLE
X x larry tfvw xx surface negative top left patch

### DIFF
--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -40,8 +40,11 @@ surface_respect_clip_rect(SDL_Surface *surface, SDL_Rect *rect)
 
     /* Left */
     if ((A->x >= B->x) && (A->x < (B->x + B->w)))
+        /* x of A is negative so we add A->x to A->w to remove the excess before setting A->x to 0*/
+        w = A->x + A->w;
         x = A->x;
     else if ((B->x >= A->x) && (B->x < (A->x + A->w)))
+        w = B->x + B->x;
         x = B->x;
     else
         return;
@@ -56,8 +59,11 @@ surface_respect_clip_rect(SDL_Surface *surface, SDL_Rect *rect)
 
     /* Top */
     if ((A->y >= B->y) && (A->y < (B->y + B->h)))
+        /* Removing the extra by adding A->y which is negative to A->h */
+        w = A->y + A->h;
         y = A->y;
     else if ((B->y >= A->y) && (B->y < (A->y + A->h)))
+        y = B->y + B->h;
         y = B->y;
     else
         return;

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -41,10 +41,10 @@ surface_respect_clip_rect(SDL_Surface *surface, SDL_Rect *rect)
     /* Left */
     if ((A->x >= B->x) && (A->x < (B->x + B->w)))
         /* x of A is negative so we add A->x to A->w to remove the excess before setting A->x to 0*/
-        w = A->x + A->w;
+        w = B->x + B->w;
         x = A->x;
     else if ((B->x >= A->x) && (B->x < (A->x + A->w)))
-        w = B->x + B->x;
+        w = A->x + A->x;
         x = B->x;
     else
         return;

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -429,6 +429,11 @@ class SurfaceTypeTest(unittest.TestCase):
         # since we are using negative coords, it should be an zero sized rect.
         self.assertEqual(tuple(r3), (0, 0, 0, 0))
 
+        # Doing same test as above, except this rect is only partially off the surface.
+        r4 = f2.fill(color2, (-16, -16, 32, 32))
+        # we should expect only the top left quadrant to be filled.
+        self.assertEqual(tuple(r4), (0, 0, 16, 16))
+
     def test_fill_keyword_args(self):
         """Ensure fill() accepts keyword arguments."""
         color = (1, 2, 3, 255)


### PR DESCRIPTION
Potentailly fixed a bug where `surface_respect_clip_rect` wouldn't subtract the extra width from fill before setting x to 0.